### PR TITLE
Add continuous integration with Travis and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: rust

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ jobs:
       - name: "Build, Test & Doc"
         script:
          - cargo build --release --verbose
-         - cargo test --release --verbose 
+         - cargo test --verbose 
          - cargo doc --verbose
       - name: "Bench"
-        script: cargo bench --release --verbose
+        script: cargo bench --verbose
       - name: "Nightly"
         rust: nightly
         script:
          - cargo build --release --verbose
-         - cargo test --release --verbose 
+         - cargo test --verbose 
       - name: "macOS"
         os: osx
         script: 
          - cargo build --release --verbose
-         - cargo test --release --verbose
+         - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: rust
 rust: beta
 
+matrix:
+  allow_failures:
+    - rust: nightly
+
 jobs:
   include:
-      - name: "Build, Test & Doc"
+      - name: "Linux"
         script:
          - cargo build --release --verbose
          - cargo test --verbose 
-         - cargo doc --verbose
-      - name: "Bench"
-        script: cargo bench --verbose
       - name: "Nightly"
         rust: nightly
         script:
@@ -20,3 +21,5 @@ jobs:
         script: 
          - cargo build --release --verbose
          - cargo test --verbose
+      - name: "Doc"
+        script: cargo doc --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,22 @@
 language: rust
+rust: beta
+
+jobs:
+  include:
+      - name: "Build, Test & Doc"
+        script:
+         - cargo build --release --verbose
+         - cargo test --release --verbose 
+         - cargo doc --verbose
+      - name: "Bench"
+         - script: cargo bench --release --verbose
+      - name: "Nightly"
+        rust: nightly
+        script:
+         - cargo build --release --verbose
+         - cargo test --release --verbose 
+      - name: "macOS"
+        os: osx
+        script: 
+         - cargo build --release --verbose
+         - cargo test --release --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
          - cargo test --release --verbose 
          - cargo doc --verbose
       - name: "Bench"
-         - script: cargo bench --release --verbose
+        script: cargo bench --release --verbose
       - name: "Nightly"
         rust: nightly
         script:

--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ options:
 Tears of Steel samples encoded with x265 using --dhdr10-info for tests.
 
 Sample JSON metadata available here: https://bitbucket.org/multicoreware/x265/downloads/
+
+# Windows builds
+Automated Windows builds can be found on [AppVeyor](https://ci.appveyor.com/project/quietvoid/hdr10plus-parser/history). Select the most recent build from the master branch, where hdr10plus_parser.exe will be available under the artifacts tab.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# hdr10plus_parser
+# hdr10plus_parser [![Travis Build Status](https://travis-ci.org/quietvoid/hdr10plus_parser.svg?branch=master)](https://travis-ci.org/quietvoid/hdr10plus_parser) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/quietvoid/hdr10plus_parser?branch=master&svg=true)](https://ci.appveyor.com/project/quietvoid/hdr10plus_parser/history)
+
 Tool to check if a HEVC file contains SMPTE 2094-40 metadata in SEI 
 messages.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2017
 
- environment:
+environment:
   host: x86_64-pc-windows-msvc        # Triple of host platform
   matrix:
     - platform: x86_64                # Name (is not used other than naming things)
@@ -13,7 +13,7 @@ matrix:
   allow_failures:                     # Allows jobs with these variables to fail
     - platform: arm64
 
- install:
+install:
     - git submodule update --init
     - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
     - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
@@ -22,18 +22,18 @@ matrix:
     - cargo -vV                       # Prints Cargo version
     - rustup target add %target%      # Adds target platform to Rust
 
- build_script:
+build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
 
- test_script:
+test_script:
     - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
 #    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
 
- artifacts:                          
+artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
       name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
 
- deploy:
+deploy:
   - provider: GitHub
     artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
     auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifact: "*.exe"
+    artifact: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.exe
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+    artifact: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.exe
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+image: Visual Studio 2017
+
+ environment:
+  host: x86_64-pc-windows-msvc        # Triple of host platform
+  matrix:
+    - platform: x86_64                # Name (is not used other than naming things)
+      target: x86_64-pc-windows-msvc  # Triple of target platform
+      channel: beta                   # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+    - platform: arm64
+      target: aarch64-pc-windows-msvc 
+      channel: beta
+matrix:
+  allow_failures:                     # Allows jobs with these variables to fail
+    - platform: arm64
+
+ install:
+    - git submodule update --init
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
+    - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
+    - rustc -vV                       # Prints Rust version
+    - cargo -vV                       # Prints Cargo version
+    - rustup target add %target%      # Adds target platform to Rust
+
+ build_script:
+    - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
+
+ test_script:
+    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
+#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
+
+ artifacts:                          
+    - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
+      name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
+
+ deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+    auth_token:
+      secure: 'QCk1JOBFqqUAqrTFPYcCLDwYduLYArXmkJCkQAVHNjdUUU5SO0qRP8EnStJnD0OB'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ deploy:
   - provider: GitHub
     artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
     auth_token:
-      secure: 'QCk1JOBFqqUAqrTFPYcCLDwYduLYArXmkJCkQAVHNjdUUU5SO0qRP8EnStJnD0OB'
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true
     on:
       appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,6 @@ test_script:
 
 artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
-      name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
 
 deploy:
   - provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifact: *.exe
+    artifact: "*.exe"
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifact: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.exe
+    artifact: *.exe
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true


### PR DESCRIPTION
Adds continuous integration with both AppVeyor and Travis CI. 

For optimal integration with GitHub, [AppVeyor](https://github.com/marketplace/appveyor) and [Travis CI](https://github.com/marketplace/travis-ci) needs to be enabled on the GitHub Marketplace.

AppVeyor builds & tests on Windows with Rust beta, while Travis builds & tests on Linux & macOS with Rust beta & nightly. 

AppVeyor also publishes the artifacts with each build. When tagging a new (pre)release, AppVeyor will also upload `hdr10plus_parser.exe`, `hdr10plus_parser.d` and `hdr10plus_parser.pdb` to GitHub, creating a release page [like this](https://github.com/EwoutH/hdr10plus_parser/releases/tag/0.2.4-test2).

To enable uploading to GitHub Releases, you need update this patch with your personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 40 (after `secure:`) in the `appveyor.yml` file. 